### PR TITLE
Refresh UI styling and add Vercel proxy rewrites

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# Projeto_vitoriacestas_Frontend
+# Frontend - Vitória Cestas (Estoque)
+
+Interface estática para consumir o backend publicado em
+`https://projeto-vitoriacestas-backend.vercel.app`. A página principal apresenta o fluxo
+sugerido, formulário de login e um painel com itens/fornecedores recentes e atalhos de
+cadastro com visual em branco + verde/verde-água.
+
+## Como usar
+1. Instale dependências (opcional; a página funciona abrindo o `index.html`, mas você pode
+   servir com qualquer servidor estático). Para deploy no **Vercel**, basta importar este
+   repositório: o `vercel.json` já cria um proxy de `/api/*` para o backend publicado.
+2. Acesse `index.html` pelo navegador ou via um servidor local.
+3. Informe **email** e **senha** utilizados no backend em "Acesso" e envie.
+4. Após o login, o painel principal mostra os últimos registros e libera os botões para
+   cadastrar item ou fornecedor.
+
+## Notas sobre as chamadas
+- API base já configurada para `https://projeto-vitoriacestas-backend.vercel.app/api`.
+  - Em produção na Vercel, chamadas usam o caminho relativo `/api` (proxy configurado em
+    `vercel.json`), evitando problemas de CORS.
+  - Para apontar a outro backend (por exemplo, ambiente de staging), defina
+    `window.APP_API_BASE` antes de carregar `main.js`.
+- O JWT retornado em `/auth/login` é salvo em `localStorage` (chave `vitoriacestas_token`).
+- Cada chamada protegida envia automaticamente `Authorization: Bearer <token>`.
+- Em caso de resposta HTML inesperada, o frontend avisa com erro de parse.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Vitória Cestas | Estoque</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="hero">
+    <div class="hero__content">
+      <p class="hero__eyebrow">Gestão de Estoque</p>
+      <h1>Vitória Cestas</h1>
+      <p class="hero__lead">
+        Acompanhe a saúde do estoque, cadastre produtos e fornecedores e mantenha toda a operação alinhada com o
+        backend já publicado.
+      </p>
+      <div class="hero__actions">
+        <button id="primaryLoginBtn" class="btn btn--primary">Fazer login</button>
+        <button id="docsBtn" class="btn btn--ghost">Abrir documentação</button>
+      </div>
+      <p class="hero__hint">Backend pronto (proxy /api para Vercel): https://projeto-vitoriacestas-backend.vercel.app</p>
+    </div>
+    <div class="hero__panel">
+      <p class="hero__panel-title">Fluxo sugerido</p>
+      <ol>
+        <li>Autentique-se e salve o JWT no navegador.</li>
+        <li>Envie o token em chamadas protegidas (Authorization: Bearer ...).</li>
+        <li>Liste itens e fornecedores antes de editar ou cadastrar.</li>
+        <li>Use mensagens da API para mostrar sucesso ou erro.</li>
+      </ol>
+    </div>
+  </header>
+
+  <main class="layout">
+    <section class="card" id="loginCard">
+      <div class="card__header">
+        <h2>Acesso</h2>
+        <p>Entre para habilitar as ações protegidas.</p>
+      </div>
+      <form id="loginForm" class="form">
+        <label class="form__field">
+          <span>Email</span>
+          <input type="email" name="email" placeholder="email@exemplo.com" required />
+        </label>
+        <label class="form__field">
+          <span>Senha</span>
+          <input type="password" name="senha" placeholder="••••••••" required />
+        </label>
+        <button type="submit" class="btn btn--primary">Entrar</button>
+      </form>
+    </section>
+
+    <section class="card card--wide" id="dashboard" hidden>
+      <div class="card__header card__header--row">
+        <div>
+          <h2>Painel principal</h2>
+          <p class="muted">Exibe os últimos itens e fornecedores após login.</p>
+        </div>
+        <div class="pill" id="authStatus">Não autenticado</div>
+      </div>
+
+      <div class="grid">
+        <div class="stack">
+          <div class="stack__header">
+            <h3>Itens recentes</h3>
+            <button class="btn btn--ghost" id="refreshItems">Atualizar</button>
+          </div>
+          <div id="itemsList" class="list">Faça login para carregar os itens.</div>
+        </div>
+
+        <div class="stack">
+          <div class="stack__header">
+            <h3>Fornecedores recentes</h3>
+            <button class="btn btn--ghost" id="refreshSuppliers">Atualizar</button>
+          </div>
+          <div id="suppliersList" class="list">Faça login para carregar os fornecedores.</div>
+        </div>
+      </div>
+
+      <div class="grid grid--cta">
+        <div class="cta" id="itemCta">
+          <div>
+            <p class="cta__eyebrow">Cadastro rápido</p>
+            <h3>Novo item</h3>
+            <p>Informe código, nome, quantidade e preço. Opcionalmente, defina descrição, categoria e fornecedor.</p>
+          </div>
+          <button class="btn btn--primary" id="openItemForm">Cadastrar item</button>
+        </div>
+
+        <div class="cta" id="supplierCta">
+          <div>
+            <p class="cta__eyebrow">Cadastro rápido</p>
+            <h3>Novo fornecedor</h3>
+            <p>Cadastre CNPJ, razão social, contato, email e telefone seguindo as validações do backend.</p>
+          </div>
+          <button class="btn btn--primary" id="openSupplierForm">Cadastrar fornecedor</button>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <dialog id="itemDialog" class="modal">
+    <div class="modal__header">
+      <h3>Cadastrar item</h3>
+      <button class="icon-btn" data-close="itemDialog">✕</button>
+    </div>
+    <form id="itemForm" class="form">
+      <label class="form__field">
+        <span>Código *</span>
+        <input name="codigo" required />
+      </label>
+      <label class="form__field">
+        <span>Nome *</span>
+        <input name="nome" required />
+      </label>
+      <label class="form__field">
+        <span>Descrição</span>
+        <textarea name="descricao" rows="2"></textarea>
+      </label>
+      <label class="form__field">
+        <span>Categoria</span>
+        <input name="categoria" />
+      </label>
+      <label class="form__field">
+        <span>Quantidade *</span>
+        <input type="number" name="quantidade" min="0" step="1" required />
+      </label>
+      <label class="form__field">
+        <span>Preço *</span>
+        <input type="number" name="preco" min="0" step="0.01" required />
+      </label>
+      <label class="form__field">
+        <span>ID do fornecedor (opcional)</span>
+        <input name="fornecedorId" />
+      </label>
+      <div class="form__actions">
+        <button type="button" class="btn btn--ghost" data-close="itemDialog">Cancelar</button>
+        <button type="submit" class="btn btn--primary">Salvar item</button>
+      </div>
+    </form>
+  </dialog>
+
+  <dialog id="supplierDialog" class="modal">
+    <div class="modal__header">
+      <h3>Cadastrar fornecedor</h3>
+      <button class="icon-btn" data-close="supplierDialog">✕</button>
+    </div>
+    <form id="supplierForm" class="form">
+      <label class="form__field">
+        <span>CNPJ *</span>
+        <input name="cnpj" required />
+      </label>
+      <label class="form__field">
+        <span>Razão social *</span>
+        <input name="razaoSocial" required />
+      </label>
+      <label class="form__field">
+        <span>Contato *</span>
+        <input name="contato" required />
+      </label>
+      <label class="form__field">
+        <span>Email *</span>
+        <input type="email" name="email" required />
+      </label>
+      <label class="form__field">
+        <span>Telefone *</span>
+        <input name="telefone" required placeholder="(00) 00000-0000" />
+      </label>
+      <label class="form__field">
+        <span>ID do endereço (opcional)</span>
+        <input name="enderecoId" />
+      </label>
+      <div class="form__actions">
+        <button type="button" class="btn btn--ghost" data-close="supplierDialog">Cancelar</button>
+        <button type="submit" class="btn btn--primary">Salvar fornecedor</button>
+      </div>
+    </form>
+  </dialog>
+
+  <div id="toast" class="toast" role="status" aria-live="polite"></div>
+
+  <script src="main.js"></script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,227 @@
+const API_BASE =
+  window.APP_API_BASE ||
+  (window.location.hostname.includes('vercel.app')
+    ? '/api'
+    : 'https://projeto-vitoriacestas-backend.vercel.app/api');
+const DOCS_URL = `${API_BASE.replace(/\/api$/, '')}/docs`;
+const storageKey = 'vitoriacestas_token';
+
+const state = {
+  token: localStorage.getItem(storageKey),
+};
+
+const elements = {
+  loginForm: document.getElementById('loginForm'),
+  loginCard: document.getElementById('loginCard'),
+  primaryLoginBtn: document.getElementById('primaryLoginBtn'),
+  docsBtn: document.getElementById('docsBtn'),
+  authStatus: document.getElementById('authStatus'),
+  dashboard: document.getElementById('dashboard'),
+  itemsList: document.getElementById('itemsList'),
+  suppliersList: document.getElementById('suppliersList'),
+  refreshItems: document.getElementById('refreshItems'),
+  refreshSuppliers: document.getElementById('refreshSuppliers'),
+  openItemForm: document.getElementById('openItemForm'),
+  openSupplierForm: document.getElementById('openSupplierForm'),
+  itemDialog: document.getElementById('itemDialog'),
+  supplierDialog: document.getElementById('supplierDialog'),
+  itemForm: document.getElementById('itemForm'),
+  supplierForm: document.getElementById('supplierForm'),
+  toast: document.getElementById('toast'),
+};
+
+function showToast(message, type = 'info') {
+  elements.toast.textContent = message;
+  elements.toast.style.borderColor = type === 'error' ? '#ef4444' : '#1f2937';
+  elements.toast.classList.add('toast--visible');
+  setTimeout(() => elements.toast.classList.remove('toast--visible'), 2200);
+}
+
+function setToken(token) {
+  state.token = token;
+  if (token) {
+    localStorage.setItem(storageKey, token);
+  } else {
+    localStorage.removeItem(storageKey);
+  }
+  syncAuthState();
+}
+
+function syncAuthState() {
+  const authenticated = Boolean(state.token);
+  elements.authStatus.textContent = authenticated ? 'Autenticado' : 'Não autenticado';
+  elements.authStatus.style.background = authenticated
+    ? 'rgba(15, 157, 88, 0.16)'
+    : 'rgba(15, 23, 42, 0.06)';
+  elements.dashboard.hidden = !authenticated;
+  if (!authenticated) {
+    elements.itemsList.textContent = 'Faça login para carregar os itens.';
+    elements.suppliersList.textContent = 'Faça login para carregar os fornecedores.';
+  }
+}
+
+async function request(path, options = {}) {
+  const headers = { 'Content-Type': 'application/json', ...(options.headers || {}) };
+  if (state.token) {
+    headers.Authorization = `Bearer ${state.token}`;
+  }
+
+  const res = await fetch(`${API_BASE}${path}`, { ...options, headers });
+  const text = await res.text();
+  let data;
+  try {
+    data = text ? JSON.parse(text) : {};
+  } catch (err) {
+    throw new Error('Resposta inesperada do servidor. Tente novamente.');
+  }
+  if (!res.ok) {
+    throw new Error(data.message || 'Erro ao processar requisição');
+  }
+  return data;
+}
+
+function renderList(container, items, type) {
+  if (!items || items.length === 0) {
+    container.textContent = 'Nenhum registro encontrado.';
+    return;
+  }
+
+  container.innerHTML = '';
+  items.slice(-5).reverse().forEach((item) => {
+    const div = document.createElement('div');
+    div.className = 'list__item';
+    if (type === 'item') {
+      div.innerHTML = `<strong>${item.nome}</strong><small>${item.codigo}</small><span class="muted">Qtd: ${item.quantidade} • Preço: R$ ${Number(item.preco || 0).toFixed(2)}</span>`;
+    } else {
+      div.innerHTML = `<strong>${item.razaoSocial || item.nome}</strong><span class="muted">Contato: ${item.contato || 'N/D'} • Email: ${item.email || 'N/D'}</span>`;
+    }
+    container.appendChild(div);
+  });
+}
+
+async function loadItems() {
+  try {
+    const { data } = await request('/items');
+    renderList(elements.itemsList, data, 'item');
+  } catch (error) {
+    showToast(error.message, 'error');
+  }
+}
+
+async function loadSuppliers() {
+  try {
+    const { data } = await request('/suppliers');
+    renderList(elements.suppliersList, data, 'supplier');
+  } catch (error) {
+    showToast(error.message, 'error');
+  }
+}
+
+function openDialog(dialog) {
+  dialog.showModal();
+}
+
+function closeDialog(dialog) {
+  dialog.close();
+}
+
+function serializeForm(form) {
+  return Object.fromEntries(new FormData(form).entries());
+}
+
+async function handleLogin(event) {
+  event.preventDefault();
+  const payload = serializeForm(elements.loginForm);
+  try {
+    const data = await request('/auth/login', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+    if (data.token) {
+      setToken(data.token);
+      showToast('Login realizado com sucesso!');
+      await Promise.all([loadItems(), loadSuppliers()]);
+    } else {
+      showToast('Token não retornado pela API.', 'error');
+    }
+  } catch (error) {
+    showToast(error.message, 'error');
+  }
+}
+
+async function handleItemSubmit(event) {
+  event.preventDefault();
+  const form = elements.itemForm;
+  const payload = serializeForm(form);
+  if (payload.quantidade < 0 || payload.preco < 0) {
+    showToast('Quantidade e preço devem ser positivos.', 'error');
+    return;
+  }
+  payload.quantidade = Number(payload.quantidade);
+  payload.preco = Number(payload.preco);
+
+  try {
+    await request('/items', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+    showToast('Item cadastrado com sucesso!');
+    form.reset();
+    closeDialog(elements.itemDialog);
+    loadItems();
+  } catch (error) {
+    showToast(error.message, 'error');
+  }
+}
+
+async function handleSupplierSubmit(event) {
+  event.preventDefault();
+  const form = elements.supplierForm;
+  const payload = serializeForm(form);
+  try {
+    await request('/suppliers', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+    showToast('Fornecedor cadastrado com sucesso!');
+    form.reset();
+    closeDialog(elements.supplierDialog);
+    loadSuppliers();
+  } catch (error) {
+    showToast(error.message, 'error');
+  }
+}
+
+function addEventListeners() {
+  elements.primaryLoginBtn.addEventListener('click', () => {
+    elements.loginCard.scrollIntoView({ behavior: 'smooth' });
+  });
+
+  elements.docsBtn.addEventListener('click', () => {
+    window.open(DOCS_URL, '_blank');
+  });
+
+  elements.loginForm.addEventListener('submit', handleLogin);
+  elements.refreshItems.addEventListener('click', loadItems);
+  elements.refreshSuppliers.addEventListener('click', loadSuppliers);
+  elements.openItemForm.addEventListener('click', () => openDialog(elements.itemDialog));
+  elements.openSupplierForm.addEventListener('click', () => openDialog(elements.supplierDialog));
+
+  document.querySelectorAll('[data-close]').forEach((btn) => {
+    btn.addEventListener('click', () => closeDialog(document.getElementById(btn.dataset.close)));
+  });
+
+  elements.itemForm.addEventListener('submit', handleItemSubmit);
+  elements.supplierForm.addEventListener('submit', handleSupplierSubmit);
+}
+
+function init() {
+  addEventListeners();
+  syncAuthState();
+  if (state.token) {
+    loadItems();
+    loadSuppliers();
+  }
+}
+
+init();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,318 @@
+:root {
+  --bg: #f7fbf8;
+  --card: #ffffff;
+  --muted: #4b5563;
+  --text: #0f172a;
+  --primary: #0f9d58;
+  --primary-strong: #0b7e46;
+  --accent: #0fb7a1;
+  --border: #d1e6d8;
+  --success: #15803d;
+  --warning: #d97706;
+  --shadow: 0 16px 40px rgba(15, 157, 88, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: linear-gradient(135deg, #e9f8ef 0%, #d8f5ea 40%, #fdfefd 100%);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: 1.3fr 1fr;
+  gap: 24px;
+  padding: 48px 56px 24px;
+  background: radial-gradient(circle at 20% 20%, rgba(15, 183, 161, 0.18), transparent 45%),
+    radial-gradient(circle at 80% 0%, rgba(15, 157, 88, 0.15), transparent 40%);
+}
+
+.hero__content h1 {
+  font-size: 48px;
+  margin: 0 0 8px;
+}
+
+.hero__lead {
+  color: var(--muted);
+  line-height: 1.6;
+  max-width: 720px;
+}
+
+.hero__eyebrow {
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--primary);
+  font-weight: 700;
+  font-size: 12px;
+  margin: 0 0 12px;
+}
+
+.hero__actions {
+  display: flex;
+  gap: 12px;
+  margin: 18px 0;
+}
+
+.hero__hint {
+  margin-top: 8px;
+  color: var(--muted);
+}
+
+.hero__panel {
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.82);
+  backdrop-filter: blur(4px);
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: var(--shadow);
+}
+
+.hero__panel-title {
+  font-weight: 700;
+  margin-top: 0;
+}
+
+.hero__panel ol {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--muted);
+  line-height: 1.8;
+}
+
+.layout {
+  padding: 0 56px 56px;
+  display: grid;
+  gap: 24px;
+}
+
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: var(--shadow);
+}
+
+.card--wide {
+  grid-column: 1 / -1;
+}
+
+.card__header {
+  margin-bottom: 16px;
+}
+
+.card__header--row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.muted {
+  color: var(--muted);
+  margin: 4px 0 0;
+}
+
+.form {
+  display: grid;
+  gap: 12px;
+}
+
+.form__field span {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.form__field input,
+.form__field textarea {
+  width: 100%;
+  padding: 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: #f7fbf8;
+  color: var(--text);
+}
+
+.form__field input:focus,
+.form__field textarea:focus {
+  outline: 2px solid var(--accent);
+  border-color: transparent;
+}
+
+.form__actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  margin-top: 12px;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border: none;
+  border-radius: 12px;
+  padding: 12px 16px;
+  font-weight: 700;
+  cursor: pointer;
+  color: #ffffff;
+  transition: transform 120ms ease, filter 120ms ease, box-shadow 120ms ease;
+  box-shadow: 0 10px 25px rgba(15, 157, 88, 0.18);
+}
+
+.btn:active {
+  transform: scale(0.98);
+}
+
+.btn--primary {
+  background: linear-gradient(135deg, var(--primary) 0%, var(--primary-strong) 100%);
+}
+
+.btn--ghost {
+  background: #e9f8ef;
+  border: 1px solid var(--border);
+  color: var(--primary-strong);
+  box-shadow: none;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 16px;
+}
+
+.grid--cta {
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+}
+
+.stack {
+  background: #f4fbf7;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 16px;
+  display: grid;
+  gap: 12px;
+}
+
+.stack__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.list {
+  display: grid;
+  gap: 8px;
+  color: var(--muted);
+}
+
+.list__item {
+  padding: 12px;
+  border-radius: 10px;
+  background: #ffffff;
+  border: 1px solid var(--border);
+  box-shadow: 0 6px 18px rgba(15, 157, 88, 0.08);
+}
+
+.list__item strong {
+  display: block;
+  color: var(--text);
+}
+
+.cta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(15, 183, 161, 0.16), rgba(15, 157, 88, 0.16));
+}
+
+.cta__eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 12px;
+  color: var(--primary-strong);
+  font-weight: 700;
+}
+
+.pill {
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: #e7f6ec;
+  border: 1px solid var(--border);
+  color: var(--primary-strong);
+}
+
+.modal {
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 16px;
+  max-width: 520px;
+  width: 90vw;
+  background: var(--card);
+  color: var(--text);
+  box-shadow: 0 20px 50px rgba(15, 157, 88, 0.18);
+}
+
+.modal::backdrop {
+  background: rgba(15, 23, 42, 0.25);
+}
+
+.modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.icon-btn {
+  background: none;
+  border: none;
+  color: var(--muted);
+  font-size: 18px;
+  cursor: pointer;
+}
+
+.toast {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: #ffffff;
+  color: var(--text);
+  border: 1px solid var(--border);
+  min-width: 200px;
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity 150ms ease, transform 150ms ease;
+  box-shadow: 0 10px 30px rgba(15, 157, 88, 0.12);
+}
+
+.toast--visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (max-width: 900px) {
+  .hero {
+    grid-template-columns: 1fr;
+    padding: 32px 24px;
+  }
+
+  .layout {
+    padding: 0 24px 32px;
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,17 @@
+{
+  "cleanUrls": true,
+  "rewrites": [
+    {
+      "source": "/api/:path*",
+      "destination": "https://projeto-vitoriacestas-backend.vercel.app/api/:path*"
+    }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "max-age=0, s-maxage=60" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- apply white/green/teal theme across landing, dashboard, modals, and toasts
- allow API base/doc URL override with Vercel-friendly default to relative /api
- add vercel.json proxy for backend and document deployment/use details in README

## Testing
- Not run (static assets only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927193591208321bda8aea6f31e84a8)