### PR TITLE
Fix login payload names and token handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
         </label>
         <label class="form__field">
           <span>Senha</span>
-          <input type="password" name="senha" placeholder="••••••••" required />
+          <input type="password" name="password" placeholder="••••••••" required />
         </label>
         <button type="submit" class="btn btn--primary">Entrar</button>
       </form>

--- a/main.js
+++ b/main.js
@@ -137,8 +137,9 @@ async function handleLogin(event) {
       method: 'POST',
       body: JSON.stringify(payload),
     });
-    if (data.token) {
-      setToken(data.token);
+    const token = data.accessToken || data.token;
+    if (token) {
+      setToken(token);
       showToast('Login realizado com sucesso!');
       await Promise.all([loadItems(), loadSuppliers()]);
     } else {


### PR DESCRIPTION
## Summary
- adjust login form field name to match backend authentication payload
- accept backend accessToken field when storing the JWT after login

## Testing
- not run (not provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692834ad305c8321a2b94c372791c1aa)