### PR TITLE
Add masked multi-page forms and logout flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,13 +54,27 @@
       </form>
     </section>
 
-    <section class="card card--wide" id="dashboard" hidden>
+    <section class="card card--wide" id="appShell" hidden>
+      <div class="shell__bar">
+        <div class="pill" id="authStatus">Não autenticado</div>
+        <div class="tabs" id="pageTabs">
+          <button type="button" data-page-target="dashboardPage" class="tabs__btn tabs__btn--active">Início</button>
+          <button type="button" data-page-target="itemsPage" class="tabs__btn">Itens</button>
+          <button type="button" data-page-target="suppliersPage" class="tabs__btn">Fornecedores</button>
+          <button type="button" data-page-target="customersPage" class="tabs__btn">Clientes</button>
+          <button type="button" data-page-target="addressesPage" class="tabs__btn">Endereços</button>
+          <button type="button" data-page-target="phonesPage" class="tabs__btn">Telefones</button>
+        </div>
+        <button type="button" class="btn btn--ghost" id="logoutBtn">Sair</button>
+      </div>
+    </section>
+
+    <section class="card card--wide page" id="dashboardPage" data-page>
       <div class="card__header card__header--row">
         <div>
           <h2>Painel principal</h2>
           <p class="muted">Exibe os últimos itens e fornecedores após login.</p>
         </div>
-        <div class="pill" id="authStatus">Não autenticado</div>
       </div>
 
       <div class="grid">
@@ -82,104 +96,217 @@
       </div>
 
       <div class="grid grid--cta">
-        <div class="cta" id="itemCta">
+        <div class="cta">
           <div>
             <p class="cta__eyebrow">Cadastro rápido</p>
-            <h3>Novo item</h3>
+            <h3>Acesse a página de itens</h3>
             <p>Informe código, nome, quantidade e preço. Opcionalmente, defina descrição, categoria e fornecedor.</p>
           </div>
-          <button class="btn btn--primary" id="openItemForm">Cadastrar item</button>
+          <button class="btn btn--primary" data-page-target="itemsPage">Abrir</button>
         </div>
 
-        <div class="cta" id="supplierCta">
+        <div class="cta">
           <div>
             <p class="cta__eyebrow">Cadastro rápido</p>
-            <h3>Novo fornecedor</h3>
-            <p>Cadastre CNPJ, razão social, contato, email e telefone seguindo as validações do backend.</p>
+            <h3>Acesse a página de fornecedores</h3>
+            <p>Cadastre CNPJ, razão social, nome do fornecedor (contato), email e telefone com validação de números.</p>
           </div>
-          <button class="btn btn--primary" id="openSupplierForm">Cadastrar fornecedor</button>
+          <button class="btn btn--primary" data-page-target="suppliersPage">Abrir</button>
         </div>
       </div>
     </section>
+
+    <section class="card card--wide page" id="itemsPage" data-page hidden>
+      <div class="card__header card__header--row">
+        <div>
+          <h2>Cadastro de itens</h2>
+          <p class="muted">Envie itens com quantidade/preço não negativos; fornecedor é opcional.</p>
+        </div>
+        <button class="btn btn--ghost" id="backToDashboard1" data-page-target="dashboardPage">Voltar</button>
+      </div>
+      <form id="itemForm" class="form">
+        <label class="form__field">
+          <span>Código *</span>
+          <input name="codigo" required />
+        </label>
+        <label class="form__field">
+          <span>Nome *</span>
+          <input name="nome" required />
+        </label>
+        <label class="form__field">
+          <span>Descrição</span>
+          <textarea name="descricao" rows="2"></textarea>
+        </label>
+        <label class="form__field">
+          <span>Categoria</span>
+          <input name="categoria" />
+        </label>
+        <label class="form__field">
+          <span>Quantidade *</span>
+          <input type="number" name="quantidade" min="0" step="1" required />
+        </label>
+        <label class="form__field">
+          <span>Preço *</span>
+          <input type="number" name="preco" min="0" step="0.01" required />
+        </label>
+        <label class="form__field">
+          <span>ID do fornecedor (opcional)</span>
+          <input name="fornecedorId" inputmode="numeric" pattern="\\d*" />
+        </label>
+        <div class="form__actions">
+          <button type="submit" class="btn btn--primary">Salvar item</button>
+        </div>
+      </form>
+    </section>
+
+    <section class="card card--wide page" id="suppliersPage" data-page hidden>
+      <div class="card__header card__header--row">
+        <div>
+          <h2>Cadastro de fornecedores</h2>
+          <p class="muted">Campos numéricos aceitam apenas dígitos; IDs vazios são enviados como 0.</p>
+        </div>
+        <button class="btn btn--ghost" id="backToDashboard2" data-page-target="dashboardPage">Voltar</button>
+      </div>
+      <form id="supplierForm" class="form">
+        <label class="form__field">
+          <span>CNPJ *</span>
+          <input name="cnpj" required maxlength="18" inputmode="numeric" autocomplete="on" />
+        </label>
+        <label class="form__field">
+          <span>Razão social *</span>
+          <input name="razaoSocial" required />
+        </label>
+        <label class="form__field">
+          <span>Nome do fornecedor (contato) *</span>
+          <input name="contato" required />
+        </label>
+        <label class="form__field">
+          <span>Email *</span>
+          <input type="email" name="email" required />
+        </label>
+        <label class="form__field">
+          <span>Telefone *</span>
+          <input name="telefone" required placeholder="(00) 00000-0000" maxlength="15" inputmode="numeric" />
+        </label>
+        <label class="form__field">
+          <span>ID do endereço (opcional)</span>
+          <input name="enderecoId" inputmode="numeric" pattern="\\d*" placeholder="0" />
+        </label>
+        <div class="form__actions">
+          <button type="submit" class="btn btn--primary">Salvar fornecedor</button>
+        </div>
+      </form>
+    </section>
+
+    <section class="card card--wide page" id="customersPage" data-page hidden>
+      <div class="card__header card__header--row">
+        <div>
+          <h2>Cadastro de clientes</h2>
+          <p class="muted">Nome, data de nascimento e endereço são obrigatórios. Telefones aceitam apenas números.</p>
+        </div>
+        <button class="btn btn--ghost" id="backToDashboard3" data-page-target="dashboardPage">Voltar</button>
+      </div>
+      <form id="customerForm" class="form">
+        <label class="form__field">
+          <span>Nome *</span>
+          <input name="nome" required />
+        </label>
+        <label class="form__field">
+          <span>CPF</span>
+          <input name="cpf" inputmode="numeric" pattern="\\d*" maxlength="14" placeholder="Somente números" />
+        </label>
+        <label class="form__field">
+          <span>CNPJ</span>
+          <input name="cnpj" inputmode="numeric" pattern="\\d*" maxlength="18" placeholder="Somente números" />
+        </label>
+        <label class="form__field">
+          <span>Email</span>
+          <input type="email" name="email" placeholder="Opcional" />
+        </label>
+        <label class="form__field">
+          <span>Data de nascimento *</span>
+          <input type="date" name="dataNascimento" required />
+        </label>
+        <label class="form__field">
+          <span>ID do endereço *</span>
+          <input name="enderecoId" required inputmode="numeric" pattern="\\d*" />
+        </label>
+        <label class="form__field">
+          <span>Telefone do cliente</span>
+          <input name="telefone" inputmode="numeric" maxlength="15" placeholder="(00) 00000-0000" />
+        </label>
+        <div class="form__actions">
+          <button type="submit" class="btn btn--primary">Salvar cliente</button>
+        </div>
+      </form>
+    </section>
+
+    <section class="card card--wide page" id="addressesPage" data-page hidden>
+      <div class="card__header card__header--row">
+        <div>
+          <h2>Cadastro de endereços</h2>
+          <p class="muted">Ao deixar campos numéricos em branco, o valor 0 é enviado.</p>
+        </div>
+        <button class="btn btn--ghost" id="backToDashboard4" data-page-target="dashboardPage">Voltar</button>
+      </div>
+      <form id="addressForm" class="form">
+        <label class="form__field">
+          <span>CEP</span>
+          <input name="cep" inputmode="numeric" pattern="\\d*" maxlength="9" placeholder="Somente números" />
+        </label>
+        <label class="form__field">
+          <span>Rua</span>
+          <input name="rua" />
+        </label>
+        <label class="form__field">
+          <span>Número</span>
+          <input name="numero" inputmode="numeric" pattern="\\d*" placeholder="0" />
+        </label>
+        <label class="form__field">
+          <span>Bairro</span>
+          <input name="bairro" />
+        </label>
+        <label class="form__field">
+          <span>Cidade</span>
+          <input name="cidade" />
+        </label>
+        <label class="form__field">
+          <span>Estado</span>
+          <input name="estado" maxlength="2" placeholder="UF" />
+        </label>
+        <label class="form__field">
+          <span>Complemento</span>
+          <input name="complemento" />
+        </label>
+        <div class="form__actions">
+          <button type="submit" class="btn btn--primary">Salvar endereço</button>
+        </div>
+      </form>
+    </section>
+
+    <section class="card card--wide page" id="phonesPage" data-page hidden>
+      <div class="card__header card__header--row">
+        <div>
+          <h2>Cadastro de telefones</h2>
+          <p class="muted">Vincule um telefone já formatado a um cliente existente.</p>
+        </div>
+        <button class="btn btn--ghost" id="backToDashboard5" data-page-target="dashboardPage">Voltar</button>
+      </div>
+      <form id="phoneForm" class="form">
+        <label class="form__field">
+          <span>Telefone *</span>
+          <input name="numero" required inputmode="numeric" maxlength="15" placeholder="(00) 00000-0000" />
+        </label>
+        <label class="form__field">
+          <span>ID do cliente *</span>
+          <input name="clienteId" required inputmode="numeric" pattern="\\d*" />
+        </label>
+        <div class="form__actions">
+          <button type="submit" class="btn btn--primary">Salvar telefone</button>
+        </div>
+      </form>
+    </section>
   </main>
-
-  <dialog id="itemDialog" class="modal">
-    <div class="modal__header">
-      <h3>Cadastrar item</h3>
-      <button class="icon-btn" data-close="itemDialog">✕</button>
-    </div>
-    <form id="itemForm" class="form">
-      <label class="form__field">
-        <span>Código *</span>
-        <input name="codigo" required />
-      </label>
-      <label class="form__field">
-        <span>Nome *</span>
-        <input name="nome" required />
-      </label>
-      <label class="form__field">
-        <span>Descrição</span>
-        <textarea name="descricao" rows="2"></textarea>
-      </label>
-      <label class="form__field">
-        <span>Categoria</span>
-        <input name="categoria" />
-      </label>
-      <label class="form__field">
-        <span>Quantidade *</span>
-        <input type="number" name="quantidade" min="0" step="1" required />
-      </label>
-      <label class="form__field">
-        <span>Preço *</span>
-        <input type="number" name="preco" min="0" step="0.01" required />
-      </label>
-      <label class="form__field">
-        <span>ID do fornecedor (opcional)</span>
-        <input name="fornecedorId" />
-      </label>
-      <div class="form__actions">
-        <button type="button" class="btn btn--ghost" data-close="itemDialog">Cancelar</button>
-        <button type="submit" class="btn btn--primary">Salvar item</button>
-      </div>
-    </form>
-  </dialog>
-
-  <dialog id="supplierDialog" class="modal">
-    <div class="modal__header">
-      <h3>Cadastrar fornecedor</h3>
-      <button class="icon-btn" data-close="supplierDialog">✕</button>
-    </div>
-    <form id="supplierForm" class="form">
-      <label class="form__field">
-        <span>CNPJ *</span>
-        <input name="cnpj" required />
-      </label>
-      <label class="form__field">
-        <span>Razão social *</span>
-        <input name="razaoSocial" required />
-      </label>
-      <label class="form__field">
-        <span>Contato *</span>
-        <input name="contato" required />
-      </label>
-      <label class="form__field">
-        <span>Email *</span>
-        <input type="email" name="email" required />
-      </label>
-      <label class="form__field">
-        <span>Telefone *</span>
-        <input name="telefone" required placeholder="(00) 00000-0000" />
-      </label>
-      <label class="form__field">
-        <span>ID do endereço (opcional)</span>
-        <input name="enderecoId" />
-      </label>
-      <div class="form__actions">
-        <button type="button" class="btn btn--ghost" data-close="supplierDialog">Cancelar</button>
-        <button type="submit" class="btn btn--primary">Salvar fornecedor</button>
-      </div>
-    </form>
-  </dialog>
 
   <div id="toast" class="toast" role="status" aria-live="polite"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -99,6 +99,37 @@ body {
   box-shadow: var(--shadow);
 }
 
+.shell__bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: space-between;
+}
+
+.tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.tabs__btn {
+  border: 1px solid var(--border);
+  background: #e9f8ef;
+  padding: 10px 14px;
+  border-radius: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  color: var(--muted);
+}
+
+.tabs__btn--active {
+  background: linear-gradient(135deg, var(--primary) 0%, var(--primary-strong) 100%);
+  color: #ffffff;
+  border-color: transparent;
+  box-shadow: 0 10px 25px rgba(15, 157, 88, 0.18);
+}
+
 .card--wide {
   grid-column: 1 / -1;
 }


### PR DESCRIPTION
## Summary
- create multi-página de cadastros para itens, fornecedores, clientes, endereços e telefones com navegação por abas
- aplicar máscaras de CNPJ/telefone e normalizar IDs numéricos com fallback 0 quando omitidos
- manter sessão via localStorage, incluir botão de logout e validar campos obrigatórios antes dos envios

## Testing
- node -c main.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69288a8bf9e88321aa8499ca017d3983)