### PR TITLE
Align deliveries endpoints and add table exports

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -63,6 +63,7 @@ textarea {
 .sidebar__nav {
   display: grid;
   gap: 10px;
+  align-content: start;
 }
 
 .sidebar__link {
@@ -151,11 +152,11 @@ textarea {
 }
 
 .phone-grid {
-  align-items: end;
+  align-items: center;
 }
 
 .phone-grid .form__group:nth-child(3) input {
-  margin-top: 8px;
+  margin-top: 0;
 }
 
 .grid--4-fixed .form__group {

--- a/src/styles.css
+++ b/src/styles.css
@@ -43,6 +43,8 @@ textarea {
   grid-template-rows: auto 1fr auto;
   gap: 16px;
   border-right: 1px solid rgba(255, 255, 255, 0.06);
+  width: 280px;
+  min-width: 280px;
 }
 
 .sidebar__logo {
@@ -146,6 +148,14 @@ textarea {
 .grid--4-fixed {
   grid-template-columns: repeat(4, minmax(0, 1fr));
   align-items: stretch;
+}
+
+.phone-grid {
+  align-items: end;
+}
+
+.phone-grid .form__group:nth-child(3) input {
+  margin-top: 8px;
 }
 
 .grid--4-fixed .form__group {

--- a/src/styles.css
+++ b/src/styles.css
@@ -143,6 +143,20 @@ textarea {
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 }
 
+.grid--4-fixed {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  align-items: stretch;
+}
+
+.grid--4-fixed .form__group {
+  height: 100%;
+}
+
+.ddi-select {
+  width: 100%;
+  min-width: 140px;
+}
+
 .card {
   padding: 16px;
   border-radius: 14px;
@@ -244,6 +258,13 @@ textarea {
   background: #fff;
 }
 
+.upload-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
 .form__group input:focus,
 .form__group textarea:focus,
 .form__group select:focus {
@@ -309,6 +330,12 @@ textarea {
   overflow: hidden;
 }
 
+.table__actions {
+  display: flex;
+  justify-content: flex-end;
+  margin: 8px 0;
+}
+
 .table__row {
   display: grid;
   grid-template-columns: 2fr 1fr 1fr 0.8fr 1fr;
@@ -348,9 +375,34 @@ textarea {
 
 .upload__preview {
   margin-top: 10px;
-  max-width: 160px;
+  max-width: 180px;
   border-radius: 12px;
   border: 1px solid var(--border);
+}
+
+.thumbnail {
+  width: 72px;
+  height: 72px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  margin-bottom: 6px;
+}
+
+.thumbnail img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.ddi-select {
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 
 .tabs {


### PR DESCRIPTION
## Summary
- switch material delivery and shipment APIs to the backend-supported routes and refresh tables immediately after each creation
- add XLS download actions above product, material, manufacturing, delivery, order, shipment, and feedback tables
- improve phone DDI select sizing for alignment while keeping flags and formatted display

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69302e20ee148321a61d896088fee5a2)