### PR TITLE
Improve address search and update UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -595,6 +595,8 @@ function AddressForm({
   const [showSearch, setShowSearch] = useState(false);
   const [searchField, setSearchField] = useState<'all' | 'id' | 'rua' | 'numero' | 'cep'>('all');
 
+  const displayedAddresses = results.length ? results : addresses;
+
   const handleSubmit = async (
     event?: React.FormEvent | React.MouseEvent<HTMLButtonElement>,
     mode: 'create' | 'update' = editing ? 'update' : 'create'
@@ -626,72 +628,62 @@ function AddressForm({
     setForm({ rua: address.rua, numero: String(address.numero), cep: address.cep });
   };
 
+  const resetSearch = () => {
+    setResults([]);
+    setSearchTerm('');
+    setShowSearch(false);
+  };
+
   return (
     <form className="form" onSubmit={(e) => handleSubmit(e, editing ? 'update' : 'create')}>
-      <div className="grid grid--3" style={{ alignItems: 'flex-end', marginBottom: '8px' }}>
-        <div className="form__group">
+      <div className="table__actions" style={{ marginBottom: '12px', justifyContent: 'space-between', gap: '12px' }}>
+        <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
           <button
             className="btn btn--ghost"
             type="button"
-            style={{ width: 'fit-content', padding: '8px 12px' }}
+            style={{ padding: '8px 12px', minWidth: 0 }}
             onClick={() => setShowSearch((prev) => !prev)}
           >
             Buscar
           </button>
-          {showSearch && (
-            <div className="search-panel" style={{ marginTop: '8px' }}>
-              <label className="form__group" style={{ marginBottom: '8px' }}>
-                <span>Campo</span>
-                <select value={searchField} onChange={(e) => setSearchField(e.target.value as any)}>
-                  <option value="all">Todos</option>
-                  <option value="id">ID</option>
-                  <option value="rua">Rua</option>
-                  <option value="numero">Número</option>
-                  <option value="cep">CEP</option>
-                </select>
-              </label>
-              <label className="form__group" style={{ marginBottom: '8px' }}>
-                <span>Pesquisar</span>
-                <input
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                  placeholder="Digite ID, rua, número ou CEP"
-                />
-              </label>
+          {editing && <span className="badge">Editando #{editing.id}</span>}
+        </div>
+        {results.length > 0 && (
+          <button className="btn btn--ghost" type="button" onClick={resetSearch}>
+            Limpar busca
+          </button>
+        )}
+      </div>
+
+      {showSearch && (
+        <div className="search-panel search-panel--inline">
+          <div className="grid grid--3" style={{ alignItems: 'flex-end' }}>
+            <label className="form__group">
+              <span>Campo</span>
+              <select value={searchField} onChange={(e) => setSearchField(e.target.value as any)}>
+                <option value="all">Todos</option>
+                <option value="id">ID</option>
+                <option value="rua">Rua</option>
+                <option value="numero">Número</option>
+                <option value="cep">CEP</option>
+              </select>
+            </label>
+            <label className="form__group">
+              <span>Pesquisar</span>
+              <input
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                placeholder="Digite ID, rua, número ou CEP"
+              />
+            </label>
+            <div className="form__actions" style={{ margin: 0, justifyContent: 'flex-start' }}>
               <button className="btn" type="button" onClick={handleSearch}>
                 Buscar
               </button>
-              {results.length > 0 && (
-                <div className="table" style={{ marginTop: '12px' }}>
-                  <div className="table__row table__head">
-                    <span>Endereço</span>
-                    <span>CEP</span>
-                  </div>
-                  {results.map((address) => (
-                    <button
-                      key={address.id || `${address.rua}-${address.numero}`}
-                      type="button"
-                      className="table__row"
-                      onClick={() => handleSelect(address)}
-                    >
-                      <span className="table__cell">{address.rua} {address.numero}</span>
-                      <span className="table__cell">{address.cep}</span>
-                    </button>
-                  ))}
-                </div>
-              )}
             </div>
-          )}
-        </div>
-        {editing && (
-          <div className="form__group">
-            <span className="muted">Editando #{editing.id}</span>
-            <button className="btn btn--ghost" type="button" onClick={() => setEditing(null)}>
-              Cancelar edição
-            </button>
           </div>
-        )}
-      </div>
+        </div>
+      )}
 
       <div className="grid grid--3">
         <label className="form__group">
@@ -719,7 +711,7 @@ function AddressForm({
           <span>Endereço</span>
           <span>CEP</span>
         </div>
-        {addresses.map((address) => {
+        {displayedAddresses.map((address) => {
           const isSelected = editing?.id === address.id;
           return (
             <button
@@ -734,7 +726,11 @@ function AddressForm({
             </button>
           );
         })}
-        {addresses.length === 0 && <div className="table__row"><span className="table__cell">Nenhum endereço cadastrado.</span></div>}
+        {displayedAddresses.length === 0 && (
+          <div className="table__row">
+            <span className="table__cell">Nenhum endereço encontrado.</span>
+          </div>
+        )}
       </div>
 
       {error && <p className="form__error">{error}</p>}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -577,18 +577,38 @@ function SectionHeader({ title, subtitle, extra }: { title: string; subtitle?: s
   );
 }
 
-function AddressForm({ onSubmit }: { onSubmit: (address: Address) => Promise<void> }) {
+function AddressForm({
+  onSubmit,
+  onSearch,
+  addresses,
+}: {
+  onSubmit: (address: Address) => Promise<void>;
+  onSearch: (term: string, field?: string) => Promise<Address[]>;
+  addresses: Address[];
+}) {
   const [form, setForm] = useState<Address>({ rua: '', cep: '', numero: '' });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [results, setResults] = useState<Address[]>([]);
+  const [editing, setEditing] = useState<Address | null>(null);
+  const [showSearch, setShowSearch] = useState(false);
+  const [searchField, setSearchField] = useState<'all' | 'id' | 'rua' | 'numero' | 'cep'>('all');
 
-  const handleSubmit = async (event: React.FormEvent) => {
-    event.preventDefault();
+  const handleSubmit = async (
+    event?: React.FormEvent | React.MouseEvent<HTMLButtonElement>,
+    mode: 'create' | 'update' = editing ? 'update' : 'create'
+  ) => {
+    event?.preventDefault();
     setLoading(true);
     setError(null);
     try {
-      await onSubmit({ ...form, cep: digitsOnly(form.cep) });
+      const payload = { ...form, id: mode === 'update' ? editing?.id : undefined, cep: digitsOnly(form.cep) } as Address;
+      await onSubmit(payload);
       setForm({ rua: '', cep: '', numero: '' });
+      if (mode === 'update') {
+        setEditing(null);
+      }
     } catch (err: any) {
       setError(err.message || 'Erro ao salvar endereço');
     } finally {
@@ -596,8 +616,83 @@ function AddressForm({ onSubmit }: { onSubmit: (address: Address) => Promise<voi
     }
   };
 
+  const handleSearch = async () => {
+    const data = await onSearch(searchTerm, searchField === 'all' ? undefined : searchField);
+    setResults(data);
+  };
+
+  const handleSelect = (address: Address) => {
+    setEditing(address);
+    setForm({ rua: address.rua, numero: String(address.numero), cep: address.cep });
+  };
+
   return (
-    <form className="form" onSubmit={handleSubmit}>
+    <form className="form" onSubmit={(e) => handleSubmit(e, editing ? 'update' : 'create')}>
+      <div className="grid grid--3" style={{ alignItems: 'flex-end', marginBottom: '8px' }}>
+        <div className="form__group">
+          <button
+            className="btn btn--ghost"
+            type="button"
+            style={{ width: 'fit-content', padding: '8px 12px' }}
+            onClick={() => setShowSearch((prev) => !prev)}
+          >
+            Buscar
+          </button>
+          {showSearch && (
+            <div className="search-panel" style={{ marginTop: '8px' }}>
+              <label className="form__group" style={{ marginBottom: '8px' }}>
+                <span>Campo</span>
+                <select value={searchField} onChange={(e) => setSearchField(e.target.value as any)}>
+                  <option value="all">Todos</option>
+                  <option value="id">ID</option>
+                  <option value="rua">Rua</option>
+                  <option value="numero">Número</option>
+                  <option value="cep">CEP</option>
+                </select>
+              </label>
+              <label className="form__group" style={{ marginBottom: '8px' }}>
+                <span>Pesquisar</span>
+                <input
+                  value={searchTerm}
+                  onChange={(e) => setSearchTerm(e.target.value)}
+                  placeholder="Digite ID, rua, número ou CEP"
+                />
+              </label>
+              <button className="btn" type="button" onClick={handleSearch}>
+                Buscar
+              </button>
+              {results.length > 0 && (
+                <div className="table" style={{ marginTop: '12px' }}>
+                  <div className="table__row table__head">
+                    <span>Endereço</span>
+                    <span>CEP</span>
+                  </div>
+                  {results.map((address) => (
+                    <button
+                      key={address.id || `${address.rua}-${address.numero}`}
+                      type="button"
+                      className="table__row"
+                      onClick={() => handleSelect(address)}
+                    >
+                      <span className="table__cell">{address.rua} {address.numero}</span>
+                      <span className="table__cell">{address.cep}</span>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+        {editing && (
+          <div className="form__group">
+            <span className="muted">Editando #{editing.id}</span>
+            <button className="btn btn--ghost" type="button" onClick={() => setEditing(null)}>
+              Cancelar edição
+            </button>
+          </div>
+        )}
+      </div>
+
       <div className="grid grid--3">
         <label className="form__group">
           <span>Rua</span>
@@ -618,10 +713,42 @@ function AddressForm({ onSubmit }: { onSubmit: (address: Address) => Promise<voi
           />
         </label>
       </div>
+
+      <div className="table" style={{ marginTop: '16px' }}>
+        <div className="table__row table__head">
+          <span>Endereço</span>
+          <span>CEP</span>
+        </div>
+        {addresses.map((address) => {
+          const isSelected = editing?.id === address.id;
+          return (
+            <button
+              key={address.id || `${address.rua}-${address.numero}`}
+              type="button"
+              className="table__row"
+              style={isSelected ? { border: '2px solid var(--primary, #35c8b4)' } : undefined}
+              onClick={() => handleSelect(address)}
+            >
+              <span className="table__cell">{address.rua} {address.numero}</span>
+              <span className="table__cell">{address.cep}</span>
+            </button>
+          );
+        })}
+        {addresses.length === 0 && <div className="table__row"><span className="table__cell">Nenhum endereço cadastrado.</span></div>}
+      </div>
+
       {error && <p className="form__error">{error}</p>}
-      <div className="form__actions">
-        <button className="btn" type="submit" disabled={loading}>
+      <div className="form__actions" style={{ gap: '8px' }}>
+        <button className="btn" type="button" disabled={loading} onClick={(e) => handleSubmit(e, 'create')}>
           {loading ? 'Salvando...' : 'Cadastrar endereço'}
+        </button>
+        <button
+          className="btn btn--ghost"
+          type="button"
+          disabled={!editing || loading}
+          onClick={(e) => handleSubmit(e, 'update')}
+        >
+          Atualizar
         </button>
       </div>
     </form>
@@ -2435,8 +2562,19 @@ function App() {
       cep: digitsOnly(payload.cep),
     };
 
+    if (payload.id) {
+      await request<Address>(`/addresses/${payload.id}`, {
+        method: 'PUT',
+        body: JSON.stringify(body),
+      });
+      setFeedback('Endereço atualizado com sucesso.');
+      await loadAddresses();
+      return;
+    }
+
     const exists = addresses.find(
-      (addr) => addr.rua.trim().toLowerCase() === body.rua.trim().toLowerCase() &&
+      (addr) =>
+        addr.rua.trim().toLowerCase() === body.rua.trim().toLowerCase() &&
         digitsOnly(addr.numero) === body.numero &&
         digitsOnly(addr.cep) === body.cep
     );
@@ -2455,6 +2593,23 @@ function App() {
     loadAddresses();
     setTimeout(loadAddresses, 2000);
   };
+
+  const searchAddresses = useCallback(
+    async (term: string, field?: string) => {
+      const query = term.trim();
+      if (!query) return [] as Address[];
+      try {
+        const url = `/addresses/search?query=${encodeURIComponent(query)}${field ? `&field=${encodeURIComponent(field)}` : ''}`;
+        const res = await request<any>(url);
+        const data = (res.data?.addresses || res.data || res.addresses || []) as Address[];
+        return data;
+      } catch (err) {
+        console.warn('Falha ao buscar endereços', err);
+        return [] as Address[];
+      }
+    },
+    [request]
+  );
 
   const handleCreatePhone = async (payload: Phone) => {
     const res = await request<Phone>('/phones', {
@@ -2676,18 +2831,12 @@ function App() {
           <p className="muted">Rua, número e CEP são obrigatórios.</p>
         </div>
       </header>
-      <AddressForm onSubmit={handleCreateAddress} />
+      <AddressForm onSubmit={handleCreateAddress} onSearch={searchAddresses} addresses={addresses} />
       <BulkImport
         label="Importar endereços (.csv/.json)"
         exampleHint="Campos: rua, numero, cep"
         onImport={importAddresses}
       />
-      <SimpleList
-        title="Endereços"
-        items={addresses as any}
-              emptyMessage="Nenhum endereço encontrado."
-              descriptor={(addr: Address) => `${addr.rua}, ${addr.numero} - CEP ${addr.cep}`}
-            />
           </div>
         );
       case 'phones':
@@ -2712,7 +2861,7 @@ function App() {
       default:
         return <Dashboard products={products} materials={materials} suppliers={suppliers} customers={customers} />;
     }
-  }, [authenticated, page, products, materials, suppliers, customers, addresses, phones, uploadImage, orders, shipments, deliveries, manufacturing, feedbackRows]);
+  }, [authenticated, page, products, materials, suppliers, customers, addresses, phones, uploadImage, orders, shipments, deliveries, manufacturing, feedbackRows, searchAddresses]);
 
   return (
     <div className="layout">


### PR DESCRIPTION
## Summary
- add toggleable side search panel for addresses with field filter and results selection
- show address table with selectable rows that populate the form and highlight the selection
- add separate create and update actions to edit selected addresses using PUT

## Testing
- not run (manual changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931d14a4f0083219803cf5c2564a897)