### PR TITLE
Normalize table search and selection

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -356,6 +356,24 @@ textarea {
   gap: 10px;
 }
 
+.table__row.is-selectable {
+  cursor: pointer;
+  transition: background 140ms ease, box-shadow 140ms ease;
+}
+
+.table__row.is-selectable:hover {
+  background: #f7fbff;
+}
+
+.table__row.is-selected {
+  box-shadow: inset 0 0 0 2px var(--primary, #35c8b4);
+  background: #f4fffc;
+}
+
+.table--addresses .table__row {
+  grid-template-columns: 2fr 1fr;
+}
+
 .table__head {
   background: #f0f4f9;
   font-weight: 700;


### PR DESCRIPTION
## Summary
- add shared search controls matching the itens pattern across addresses, produtos, clientes, fornecedores e telefones
- align all entity tables to the endereço-style selectable rows for consistent update flows
- keep address search clearing behavior while preserving editable row prefilling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931ff408bb8832197b21d6e0a5846d5)